### PR TITLE
Import upath fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module demo.book.com
+
+go 1.14
+
+require (
+	github.com/go-sql-driver/mysql v1.5.0
+	github.com/go-xorm/xorm v0.7.9
+	github.com/kataras/iris/v12 v12.1.9-0.20200601035752-8359c9a0f5b0
+)

--- a/main.go
+++ b/main.go
@@ -1,16 +1,18 @@
 package main
 
 import (
-	"demo.book.com/conf"
-	"demo.book.com/web/controllers"
 	"fmt"
-	"github.com/kataras/iris"
-	"github.com/kataras/iris/middleware/logger"
-	"github.com/kataras/iris/mvc"
 	"io"
 	"os"
 	"runtime"
 	"time"
+
+	"demo.book.com/conf"
+	"demo.book.com/web/controllers"
+
+	"github.com/kataras/iris/v12"
+	"github.com/kataras/iris/v12/middleware/logger"
+	"github.com/kataras/iris/v12/mvc"
 )
 
 func main() {
@@ -76,9 +78,7 @@ func main() {
 				// 打印错误日志
 				ctx.Application().Logger().Warn(logMessage)
 				// 返回错误信息
-				ctx.JSON(errMsg)
-				ctx.StatusCode(500)
-				ctx.StopExecution()
+				ctx.StopWithJSON(iris.StatusInternalServerError, errMsg)
 			}
 		}()
 		ctx.Next()

--- a/web/controllers/BookController.go
+++ b/web/controllers/BookController.go
@@ -2,9 +2,11 @@ package controllers
 
 import (
 	"demo.book.com/conf"
+	"demo.book.com/models"
 	"demo.book.com/services"
-	"github.com/kataras/iris"
-	"github.com/kataras/iris/mvc"
+
+	"github.com/kataras/iris/v12"
+	"github.com/kataras/iris/v12/mvc"
 )
 
 type BookController struct {
@@ -26,12 +28,12 @@ func (c *BookController) Get() mvc.Result {
 }
 
 ///book/ajaxbooks?key=go	访问地址是小写的
-func (c *BookController) GetAjaxbooks() {
+func (c *BookController) GetAjaxbooks() []models.BookTb {
 	//获取url参数
 	key := c.Ctx.URLParam("key")
 
 	service := services.NewBookService()
 	list := service.GetList(" bookName like '%"+key+"%'", "ID asc", 0)
 
-	c.Ctx.JSON(list)
+	return list
 }

--- a/web/controllers/DemoController.go
+++ b/web/controllers/DemoController.go
@@ -1,12 +1,14 @@
 package controllers
 
 import (
+	"errors"
+
 	"demo.book.com/conf"
 	"demo.book.com/models"
 	"demo.book.com/services"
-	"errors"
+
 	"github.com/go-xorm/xorm"
-	"github.com/kataras/iris"
+	"github.com/kataras/iris/v12"
 )
 
 type DemoController struct {
@@ -15,7 +17,7 @@ type DemoController struct {
 }
 
 //自己实例化engine，获取单条数据
-func (c *DemoController) GetRecord1() {
+func (c *DemoController) GetRecord1() models.BookTb {
 	engine, _ := xorm.NewEngine("mysql", "root:112233@tcp(127.0.0.1:3305)/mygo?charset=utf8")
 	var info models.BookTb
 
@@ -23,12 +25,11 @@ func (c *DemoController) GetRecord1() {
 	engine.ShowSQL(true)
 
 	engine.Table("book_tb").Where("id=?", 1).Get(&info)
-
-	c.Ctx.JSON(info)
+	return info
 }
 
 //封装的单条记录
-func (c *DemoController) GetOrm() {
+func (c *DemoController) GetOrm() iris.Map {
 	//实例对象
 	service := services.NewBookService()
 	//ID获取单条数据
@@ -39,13 +40,12 @@ func (c *DemoController) GetOrm() {
 	total, pageList := service.GetPageList("", "ID asc", 0, 2)
 	//新增数据
 
-	c.Ctx.JSON(
-		iris.Map{
-			"list":     list,
-			"info":     info,
-			"pageList": pageList,
-			"total":    total,
-		})
+	return iris.Map{
+		"list":     list,
+		"info":     info,
+		"pageList": pageList,
+		"total":    total,
+	}
 }
 
 //返回xml
@@ -61,15 +61,16 @@ func (c *DemoController) GetErr() {
 	//引发一个恐慌，程序会自动捕获并返回错误信息
 	panic(errors.New("i'm a painc"))
 }
-func (c *DemoController) GetQps() {
-	c.Ctx.WriteString("hello")
+func (c *DemoController) GetQps() string {
+	return "hello"
 }
 
-func (c *DemoController) GetConf() {
+func (c *DemoController) GetConf() map[string]string {
 	reload := c.Ctx.URLParam("reload")
 	if reload != "" {
 		//如果有更新配置，重新读取配置文件
 		conf.ReLoad()
 	}
-	c.Ctx.JSON(conf.SysConfMap)
+
+	return conf.SysConfMap
 }


### PR DESCRIPTION
Hello @imleaf, I've read your article at: https://developpaper.com/iris-mvc-xorm-go-web-site-development-including-complete-source-code/

At October of 2019 the import path changed  to match the new implementation and the official recommendations of the new `go get` command. You have to use the `github.com/kataras/iris/v12` instead. This PR fixes your import paths and adds a `go.mod` in your project root.

Please **update your article too** so I can share it to the community.

Thank you,
Gerasimos Maropoulos. Author of Iris 